### PR TITLE
Make install_requires delfick_error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
 
     , install_requires =
       [ 'six'
+      , 'delfick_error==1.7.3'
       ]
 
     , extras_require =
@@ -15,7 +16,6 @@ setup(
         [ "noseOfYeti>=1.4.9"
         , "nose"
         , "mock"
-        , 'delfick_error==1.7.3'
         ]
       }
 


### PR DESCRIPTION
formatter and storage both import delfick_error. this needs to be moved
to install_requires from extras_require so that install will work
correctly.
